### PR TITLE
fix: remove GPU device reservation from docker-compose (#128)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,10 +8,11 @@ MONGO_URL=mongodb://mongodb:27017
 MONGO_DB_NAME=
 
 # auth-service (issues tokens; this backend only verifies them against its JWKS).
-# Running this backend directly (not in Docker): http://localhost:8100
-# Running this backend via Backend/docker-compose.yml, with auth-service's own
-# compose stack also running on the same host: http://host.docker.internal:8100
-AUTH_SERVICE_URL=http://localhost:8100
+# Default below matches the primary documented path — running this backend via
+# Backend/docker-compose.yml, with auth-service's own compose stack also
+# running on the same host. Running this backend directly (not in Docker)
+# instead: use http://localhost:8100.
+AUTH_SERVICE_URL=http://host.docker.internal:8100
 
 
 # LLM Provider Defaults

--- a/Backend/docker-compose.yml
+++ b/Backend/docker-compose.yml
@@ -30,13 +30,6 @@ services:
     # the box on Docker Desktop; needed explicitly on Linux.
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities: ["gpu"]
 
   ragulate-rag:
     build:


### PR DESCRIPTION
Closes #128.

`backend`'s GPU device reservation block was vestigial from an earlier local-HF-inference design — `api_v2` does no local ML inference, and the block was blocking `docker compose up` outright on non-GPU hosts. Removed; verified live with a full register→login→chat/list→create-chat flow.