### PR TITLE
fix: make CORS origins configurable, stop leaking the OpenRouter key from /debug-config (#130)

### DIFF
--- a/Backend/api_v2/app/config.py
+++ b/Backend/api_v2/app/config.py
@@ -14,6 +14,13 @@ class Settings(BaseModel):
     # auth-service (issues tokens, we only verify them against its JWKS)
     auth_service_url: str = os.getenv("AUTH_SERVICE_URL", "http://localhost:8100")
 
+    # Comma-separated list of allowed browser origins for this API's CORS policy
+    cors_allowed_origins: list[str] = [
+        origin.strip()
+        for origin in os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000").split(",")
+        if origin.strip()
+    ]
+
     # LLM Provider Settings
     openrouter_api_key: str | None   = os.getenv("OPENROUTER_API_KEY")
     openrouter_base_url: str         = os.getenv("OPENROUTER_BASE_URL")

--- a/Backend/api_v2/app/main.py
+++ b/Backend/api_v2/app/main.py
@@ -22,13 +22,11 @@ def create_app() -> FastAPI:
         redoc_url="/redoc",
     )
 
-    origins = [
-        "http://localhost:3000",
-    ]
+    settings = get_settings()
 
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=origins,
+        allow_origins=settings.cors_allowed_origins,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
@@ -84,7 +82,6 @@ def debug_config():
     settings = get_settings()
     return {
         "openrouter": bool(settings.openrouter_api_key),
-        "key": settings.openrouter_api_key,
         "ollama_base_url": bool(settings.ollama_base_url),
         "mongo_url": settings.mongo_url,
         "mongo_db": settings.mongo_db_name


### PR DESCRIPTION
Closes #130.

`main.py`'s CORS middleware was hardcoded to `["http://localhost:3000"]`; now reads a comma-separated `CORS_ALLOWED_ORIGINS` env var via a new `Settings.cors_allowed_origins`. Also: `/debug-config` returned the raw OpenRouter API key — now returns only a boolean presence check, matching the other provider fields.