### PR TITLE
fix: unblock chat — it was gated on a per-user API key that can never be set (#131)

### DIFF
--- a/Frontend/app/page.tsx
+++ b/Frontend/app/page.tsx
@@ -123,7 +123,11 @@ function GDPRChatbotInner() {
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState<string>("");
   const [showApiKeyPrompt, setShowApiKeyPrompt] = useState(false);
-  const [hasApiKey, setHasApiKey] = useState(false);
+  // Chat uses this backend's own server-side OPENROUTER_API_KEY (Backend/.env),
+  // not a per-user key — there's no working endpoint to check for one (see
+  // RAGulate_v2#113), so this must default to true or chat is permanently
+  // blocked. Flip this back to false-by-default once #113 actually lands.
+  const [hasApiKey, setHasApiKey] = useState(true);
 
   // UI References and state
   const messagesEndRef = useRef<HTMLDivElement>(null); // For auto-scrolling


### PR DESCRIPTION
Closes #131.

`hasApiKey` defaulted to `false` and could only become `true` via a fetch to `/api/user/api-key`, an endpoint that doesn't exist on this backend (removed in the #121 auth migration, never really implemented on `main` before that either). Since a 404 doesn't throw in `fetch()`, the catch-fallback that would've shown the API-key prompt never fired either — `hasApiKey` stayed permanently `false` and chat was unusable for everyone, regardless of the server-side `OPENROUTER_API_KEY` that `llm_service.py` actually uses for every call.

Stopgap: default `hasApiKey` to `true`, with a comment pointing at #113 (real per-user key management) as the proper fix.