### PR TITLE
fix: warm up ragulate-rag's LightRAG engine on startup, not on first query (#132)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,4 +28,6 @@ OLLAMA_MODEL=
 # Running this backend directly (not in Docker): http://localhost:8181
 # Running via Backend/docker-compose.yml: http://ragulate-rag:8081
 RAGULATE_RAG_URL=http://localhost:8181
-RAGULATE_RAG_TIMEOUT=30
+# ragulate-rag warms up its engine (embeddings, Neo4j, local reranker model)
+# on its own startup, but give this some headroom for slower/GPU-less hosts.
+RAGULATE_RAG_TIMEOUT=60

--- a/Backend/api_v2/app/config.py
+++ b/Backend/api_v2/app/config.py
@@ -26,7 +26,7 @@ class Settings(BaseModel):
     # ragulate-rag (Backend/ragulate-rag/) — optional: chat still works
     # without it, just without retrieval, if unset or unreachable.
     ragulate_rag_url: str | None = os.getenv("RAGULATE_RAG_URL")
-    ragulate_rag_timeout: float  = float(os.getenv("RAGULATE_RAG_TIMEOUT", "30"))
+    ragulate_rag_timeout: float  = float(os.getenv("RAGULATE_RAG_TIMEOUT", "60"))
 
 
 @lru_cache

--- a/Backend/ragulate-rag/app/api/routes.py
+++ b/Backend/ragulate-rag/app/api/routes.py
@@ -31,8 +31,13 @@ _rag_init_lock = asyncio.Lock()
 
 
 
-async def _get_rag():
-    """Return (and cache) the LightRAG instance."""
+async def get_rag_instance():
+    """Return (and cache) the LightRAG instance.
+
+    Also called from the app lifespan on startup, so the cold-start cost
+    (reranker model load, Neo4j index setup) happens during container boot
+    instead of on a real user's first query.
+    """
     global _rag_instance
     if _rag_instance is not None:
         return _rag_instance
@@ -58,7 +63,7 @@ async def query_rag(request: QueryRequest):
     logger.info("Received query: %.120s …  [mode=%s]", request.query, request.mode)
 
     try:
-        rag = await _get_rag()
+        rag = await get_rag_instance()
 
         # Map enum value
         mode = request.mode.value

--- a/Backend/ragulate-rag/app/main.py
+++ b/Backend/ragulate-rag/app/main.py
@@ -8,11 +8,12 @@ Run with:
     uvicorn app.main:app --reload --port 8081
 """
 import logging
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api.routes import router as rag_router
+from app.api.routes import router as rag_router, get_rag_instance
 from app.api.evaluation_routes import router as evaluation_router
 from app.api.pdf_routes import router as pdf_router
 
@@ -23,6 +24,22 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s  %(levelname)-8s  %(name)s  %(message)s",
 )
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Warm up the LightRAG engine (embeddings, Neo4j, the local reranker
+    # model) here rather than letting it lazily initialise on the first real
+    # /api/query call — that cold start can take over a minute and was
+    # blowing past api_v2's request timeout, silently losing retrieval for
+    # whoever sent the first chat message after this service started.
+    logger.info("Warming up LightRAG engine on startup …")
+    await get_rag_instance()
+    logger.info("LightRAG engine warm and ready.")
+    yield
+
 
 # ---------------------------------------------------------------------------
 # FastAPI app
@@ -36,6 +53,7 @@ app = FastAPI(
         "EDPB guidance as a starting corpus) and returns relevant context."
     ),
     version="0.1.0",
+    lifespan=lifespan,
 )
 
 # ---------------------------------------------------------------------------

--- a/Common/Backend/Architecture/rag_system.md
+++ b/Common/Backend/Architecture/rag_system.md
@@ -36,6 +36,17 @@ its own copy rather than sharing one running instance. See
 6. If `ragulate-rag` is unset or unreachable, this degrades gracefully
    to plain LLM chat rather than failing the request
 
+## Cold start
+
+`ragulate-rag` warms up its LightRAG engine (embeddings, Neo4j
+connection, and the local reranker model, `BAAI/bge-reranker-v2-m3`) in
+its own FastAPI lifespan on startup, not lazily on the first
+`/api/query` call — that first initialisation can take over a minute,
+which used to exceed `api_v2`'s `RAGULATE_RAG_TIMEOUT` and silently drop
+retrieval for whoever sent the first chat message after the container
+started. `RAGULATE_RAG_TIMEOUT` (default 60s) still exists as a safety
+margin for slower hosts.
+
 ## Implementation
 
 `Backend/api_v2/app/services/rag_service.py` — calls out to


### PR DESCRIPTION
Closes #132.

The engine (embeddings, Neo4j, local reranker model) only initialised lazily on the first `/api/query` call — took ~65s in testing, longer than `RAGULATE_RAG_TIMEOUT` (30s), so the first chat message after startup silently lost retrieval. Now warmed up in `ragulate-rag`'s FastAPI lifespan instead, moving that cost to container boot. Also bumped the default timeout to 60s as defense-in-depth.