### PR TITLE
docs: fix ingestion instructions to run inside the ragulate-rag container (#133)

### DIFF
--- a/Common/Backend/Architecture/rag_system.md
+++ b/Common/Backend/Architecture/rag_system.md
@@ -47,6 +47,17 @@ wrapper (`rag/engine.py`), ingestion (`rag/ingestion.py`,
 `scripts/ingest.py`, offline/batch only — no ingestion API), and the
 query/PDF-source/evaluation routes (`api/`).
 
+**Ingestion storage**: LightRAG's KV/vector store (`RAG_WORKING_DIR`)
+is a relative path, resolved against wherever the process actually
+runs. Under `Backend/docker-compose.yml`, that storage lives in a
+Docker volume (`ragulate_rag_working_dir`) mounted at
+`/app/rag_working_dir` *inside* the container — so `scripts/ingest.py`
+must be run inside that same container (`docker compose exec
+ragulate-rag python scripts/ingest.py`), not on the host. A host-side
+run writes to an unrelated folder on disk that the query service never
+reads, so ingestion appears to succeed while every subsequent query
+still returns zero results (see #133).
+
 ## Supported LLM Providers (chat)
 
 - OpenRouter API

--- a/README.md
+++ b/README.md
@@ -134,11 +134,11 @@ This starts:
 
 The API docs are available at `http://localhost:8000/docs` once running.
 
-The GDPR corpus (PDFs + extracted text) ships already checked in, but the knowledge graph itself has to be built once by running the ingestion script (makes real LLM calls for entity extraction — do this with your own key, not repeatedly):
+The GDPR corpus (PDFs + extracted text) ships already checked in, but the knowledge graph itself has to be built once by running the ingestion script (makes real LLM calls for entity extraction — do this with your own key, not repeatedly). Run it **inside the running container**, not on the host — `ragulate-rag`'s LightRAG storage (`RAG_WORKING_DIR`) lives in a Docker volume mounted into the container; a host-side `python scripts/ingest.py` writes to a plain folder on your machine instead and the query service will never see that data:
 ```bash
-cd Backend/ragulate-rag
-python scripts/ingest.py
+docker compose exec ragulate-rag python scripts/ingest.py
 ```
+(Running `ragulate-rag` directly, not via Docker Compose? Then `cd Backend/ragulate-rag && python scripts/ingest.py` on the host is correct — it's the same process reading `./rag_working_dir` either way.)
 
 > **GPU support**: see [`Common/Backend/Setup/5_Docker_GPU_Support.md`](Common/Backend/Setup/5_Docker_GPU_Support.md).
 


### PR DESCRIPTION
Closes #133.

README told people to run `python scripts/ingest.py` on the host. Under `Backend/docker-compose.yml`, the query service's LightRAG storage is a Docker volume mounted inside the container — a host-side run writes to an unrelated folder on disk instead, so ingestion appears to succeed (real entities/chunks, real Neo4j writes) while every query against the running service still returns zero results. Fixed to document `docker compose exec ragulate-rag python scripts/ingest.py`.