### PR TITLE
fix: clear folders/chats state on logout (#135)

### DIFF
--- a/Frontend/app/page.tsx
+++ b/Frontend/app/page.tsx
@@ -861,11 +861,31 @@ function GDPRChatbotInner() {
   };
 
   /**
+   * Clears chat/folder UI state left over from a previous session — used
+   * both when a new user logs in (replacing the old user's data) and when
+   * the user logs out (so the previous user's folders/chats don't stay
+   * rendered underneath the blurred login overlay).
+   */
+  const clearUserState = () => {
+    setFolders([]);
+    setSessions([]);
+    setMessages([]);
+    setActiveFolderId(null);
+    setActiveSessionId(null);
+    setEditingFolderId(null);
+    setEditingSessionId(null);
+    setEditedTitle("");
+  };
+
+  /**
    * Loads Sidebar content. Contains Sessions and Folders
    */
   useEffect(() => {
     const loadSidebarData = async () => {
-      if (!username) return;
+      if (!username) {
+        clearUserState();
+        return;
+      }
 
       /* 1. Folder */
       const rawFolders = await fetchFolders();
@@ -896,15 +916,7 @@ function GDPRChatbotInner() {
    * chat UI state left over from a previous session and checks for an API key.
    */
   const handleLoginSuccess = async () => {
-    // RESET OLD USER STATE
-    setFolders([]);
-    setSessions([]);
-    setMessages([]);
-    setActiveFolderId(null);
-    setActiveSessionId(null);
-    setEditingFolderId(null);
-    setEditingSessionId(null);
-    setEditedTitle("");
+    clearUserState();
 
     try {
       const res = await fetch(`${BACKEND_URL}/api/user/api-key`, {


### PR DESCRIPTION
Closes #135.

The sidebar-loading effect only ever populated `folders`/`sessions` when `username` became truthy — it never cleared them when `username` went back to `null` on logout. The previous user's folders and chats stayed mounted and visibly rendered underneath the blurred login overlay (just non-interactive via `pointer-events-none`), a real privacy issue on a shared machine. Extracted the reset list already used by `handleLoginSuccess` into a shared `clearUserState()` and call it in both places.